### PR TITLE
Add chat history dividers and serializer tests

### DIFF
--- a/frontend/static/css/chat.css
+++ b/frontend/static/css/chat.css
@@ -270,6 +270,7 @@ chat-view[data-rendering="true"] #chat {
       border-radius: var(--radius-sm);
     }
   }
+
 }
 
 #message-form {
@@ -388,6 +389,91 @@ chat-view[data-rendering="true"] #chat {
       cursor: default;
     }
   }
+}
+
+.message-divider {
+  --divider-phase-color: color-mix(in srgb, var(--brand-accent), transparent 68%);
+  --divider-phase-soft: color-mix(in srgb, var(--brand-accent-15), transparent 40%);
+
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+  color: var(--color-text-muted);
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-weight: 600;
+  align-self: stretch;
+  padding: 0;
+  margin: var(--spacing-xs) 0;
+}
+
+.message-divider::before,
+.message-divider::after {
+  content: "";
+  flex: 1 1 auto;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, var(--divider-phase-color));
+  opacity: 0.8;
+}
+
+.message-divider::after {
+  background: linear-gradient(270deg, transparent, var(--divider-phase-color));
+}
+
+.message-divider__content {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--divider-phase-soft), transparent 70%);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--divider-phase-color), transparent 60%);
+  color: inherit;
+}
+
+.message-divider__phase {
+  font-weight: 600;
+}
+
+.message-divider__bullet {
+  opacity: 0.65;
+}
+
+.message-divider__time {
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.08em;
+}
+
+.message-divider[data-phase="night"] {
+  --divider-phase-color: color-mix(in srgb, var(--brand-accent), transparent 55%);
+  --divider-phase-soft: color-mix(in srgb, var(--brand-accent-25), transparent 45%);
+}
+
+.message-divider[data-phase="early-morning"] {
+  --divider-phase-color: color-mix(in srgb, var(--accent), transparent 40%);
+  --divider-phase-soft: color-mix(in srgb, var(--accent-15), transparent 25%);
+}
+
+.message-divider[data-phase="morning"] {
+  --divider-phase-color: color-mix(in srgb, var(--accent-active), transparent 35%);
+  --divider-phase-soft: color-mix(in srgb, var(--accent-10), transparent 15%);
+}
+
+.message-divider[data-phase="afternoon"] {
+  --divider-phase-color: color-mix(in srgb, var(--color-success-text), transparent 45%);
+  --divider-phase-soft: color-mix(in srgb, var(--color-success-bg), transparent 25%);
+}
+
+.message-divider[data-phase="evening"] {
+  --divider-phase-color: color-mix(in srgb, var(--color-danger), transparent 55%);
+  --divider-phase-soft: color-mix(in srgb, var(--color-danger-bg), transparent 30%);
+}
+
+.message-divider[data-phase="late-night"] {
+  --divider-phase-color: color-mix(in srgb, var(--brand-accent), transparent 48%);
+  --divider-phase-soft: color-mix(in srgb, var(--brand-accent-15), transparent 32%);
 }
 
 /* animations */

--- a/frontend/static/js/components/chat-view.js
+++ b/frontend/static/js/components/chat-view.js
@@ -397,13 +397,16 @@ export class ChatView extends ReactiveElement {
       }
 
       if (target?.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
-        target.querySelectorAll?.(".message").forEach((node) => {
+        target.querySelectorAll?.(".message, .message-divider").forEach((node) => {
           activateAnimations(node);
         });
         return;
       }
 
-      if (target?.classList?.contains("message")) {
+      if (
+        target?.classList?.contains("message") ||
+        target?.classList?.contains("message-divider")
+      ) {
         activateAnimations(target);
       }
     });

--- a/src/llamora/app/services/chat_context.py
+++ b/src/llamora/app/services/chat_context.py
@@ -6,8 +6,9 @@ from typing import Any, Mapping
 
 from llamora.app.services.auth_helpers import get_secure_cookie_manager
 from llamora.app.services.container import get_services
+from llamora.app.services.history_serializer import serialize_history_for_view
 from llamora.app.services.markdown import render_markdown_to_html
-from llamora.app.services.time import local_date
+from llamora.app.services.time import get_timezone, local_date
 
 
 async def get_chat_context(
@@ -42,8 +43,11 @@ async def get_chat_context(
 
     opening_stream = not history and is_today
 
+    tz = get_timezone()
+    rendered_history = serialize_history_for_view(history, tz)
+
     return {
-        "history": history,
+        "history": rendered_history,
         "pending_msg_id": pending_msg_id,
         "is_today": is_today,
         "opening_stream": opening_stream,

--- a/src/llamora/app/services/history_serializer.py
+++ b/src/llamora/app/services/history_serializer.py
@@ -1,0 +1,134 @@
+"""Helpers for preparing chat history items for rendering."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Mapping, Sequence
+
+from zoneinfo import ZoneInfo
+
+from .time import part_of_day
+
+
+logger = logging.getLogger(__name__)
+
+UTC = ZoneInfo("UTC")
+
+
+PHASE_LABELS: dict[str, str] = {
+    "night": "Night",
+    "early-morning": "Early Morning",
+    "morning": "Morning",
+    "afternoon": "Afternoon",
+    "evening": "Evening",
+    "late-night": "Late Night",
+}
+
+
+@dataclass(slots=True)
+class HistoryDivider:
+    """Presentation metadata describing a divider element."""
+
+    block_id: str
+    phase: str
+    phase_label: str
+    time_label: str
+    label: str
+    datetime_iso: str
+    accessible_label: str
+    sr_skip: bool = False
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "item_type": "divider",
+            "id": self.block_id,
+            "phase": self.phase,
+            "phase_label": self.phase_label,
+            "time_label": self.time_label,
+            "label": self.label,
+            "datetime": self.datetime_iso,
+            "accessible_label": self.accessible_label,
+            "sr_skip": self.sr_skip,
+        }
+
+
+def _parse_datetime(value: Any) -> datetime:
+    if isinstance(value, datetime):
+        dt = value
+    elif isinstance(value, str):
+        raw = value.replace("Z", "+00:00")
+        try:
+            dt = datetime.fromisoformat(raw)
+        except ValueError:
+            logger.debug("Unable to parse created_at '%s'", value)
+            dt = datetime.now(UTC)
+    else:
+        dt = datetime.now(UTC)
+
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC)
+
+
+def _resolve_timezone(name: str | None) -> ZoneInfo:
+    if not name:
+        return UTC
+
+    try:
+        return ZoneInfo(name)
+    except Exception:
+        logger.debug("Invalid timezone '%s' for history divider rendering", name)
+        return UTC
+
+
+def _divider_from_datetime(block_dt: datetime) -> HistoryDivider:
+    phase = part_of_day(block_dt)
+    phase_label = PHASE_LABELS.get(phase, phase.replace("-", " ").title())
+    time_label = block_dt.strftime("%H:%M")
+    label = f"{phase_label} • {time_label}"
+    accessible_label = f"{phase_label} at {time_label}"
+    block_id = f"divider-{block_dt.strftime('%Y%m%dT%H')}"
+    return HistoryDivider(
+        block_id=block_id,
+        phase=phase,
+        phase_label=phase_label,
+        time_label=time_label,
+        label=label,
+        datetime_iso=block_dt.isoformat(),
+        accessible_label=accessible_label,
+    )
+
+
+def serialize_history_for_view(
+    history: Sequence[Mapping[str, Any] | dict[str, Any]],
+    timezone_name: str | None,
+) -> list[dict[str, Any]]:
+    """Expand ``history`` with divider entries for display.
+
+    ``history`` is expected to be ordered chronologically. A divider entry is
+    inserted whenever the local hour bucket changes. Returned entries include an
+    ``item_type`` key to distinguish divider metadata from message dictionaries.
+    """
+
+    tz = _resolve_timezone(timezone_name)
+    items: list[dict[str, Any]] = []
+    last_block: tuple[int, int] | None = None
+
+    for entry in history:
+        message = dict(entry)
+        created_at = _parse_datetime(message.get("created_at"))
+        local_dt = created_at.astimezone(tz)
+        block_dt = local_dt.replace(minute=0, second=0, microsecond=0)
+        block_key = (block_dt.date(), block_dt.hour)
+
+        if last_block != block_key:
+            divider = _divider_from_datetime(block_dt)
+            items.append(divider.as_dict())
+            last_block = block_key
+
+        message["item_type"] = "message"
+        items.append(message)
+
+    return items

--- a/src/llamora/app/templates/partials/history.html
+++ b/src/llamora/app/templates/partials/history.html
@@ -14,36 +14,42 @@
   {% if not history|length and not is_today %}
   <div class="no-content">Nothing was written this day.</div>
   {% endif %}
-  {% for msg in history %}
-  {% set msg_meta = msg.get('meta', {}) %}
-  {% set is_error = msg_meta.get('error') %}
-  {% set repeat_guard = msg_meta.get('repeat_guard') %}
-  {% set speaker = 'Your' if msg['role'] == 'user' else 'Assistant' %}
-  <div id="msg-{{ msg['id'] }}"
-       class="message {{ 'assistant' if msg['role'] != 'user' else 'user'}}{% if is_error %} message--error{% endif %}"
-       {% if repeat_guard %}data-repeat-guard="true"{% endif %}
-       role="article"
-       aria-labelledby="msg-{{ msg['id'] }}-speaker msg-{{ msg['id'] }}-body">
-    <span class="visually-hidden" id="msg-{{ msg['id'] }}-speaker">{{ speaker }} message</span>
-    {% set rendered = msg.get('message_html') %}
-    <div class="markdown-body"
-         id="msg-{{ msg['id'] }}-body"{% if rendered is not none %} data-rendered="true"{% endif %}>
-      {% if rendered is not none %}
-      {{ rendered | safe }}
-      {% else %}
-      {{ msg.message }}
+  {% for item in history %}
+    {% if item.item_type == 'divider' %}
+      {% set divider = item %}
+      {% include 'partials/message_divider.html' %}
+      {% continue %}
+    {% endif %}
+    {% set msg = item %}
+    {% set msg_meta = msg.get('meta', {}) %}
+    {% set is_error = msg_meta.get('error') %}
+    {% set repeat_guard = msg_meta.get('repeat_guard') %}
+    {% set speaker = 'Your' if msg['role'] == 'user' else 'Assistant' %}
+    <div id="msg-{{ msg['id'] }}"
+         class="message {{ 'assistant' if msg['role'] != 'user' else 'user'}}{% if is_error %} message--error{% endif %}"
+         {% if repeat_guard %}data-repeat-guard="true"{% endif %}
+         role="article"
+         aria-labelledby="msg-{{ msg['id'] }}-speaker msg-{{ msg['id'] }}-body">
+      <span class="visually-hidden" id="msg-{{ msg['id'] }}-speaker">{{ speaker }} message</span>
+      {% set rendered = msg.get('message_html') %}
+      <div class="markdown-body"
+           id="msg-{{ msg['id'] }}-body"{% if rendered is not none %} data-rendered="true"{% endif %}>
+        {% if rendered is not none %}
+        {{ rendered | safe }}
+        {% else %}
+        {{ msg.message }}
+        {% endif %}
+      </div>
+      {% if repeat_guard %}
+      <span class="repeat-guard-indicator repeat-guard-indicator--visible repeat-guard-indicator--calm">
+        <span class="repeat-guard-indicator__label">response trimmed</span>
+        <span class="visually-hidden">Response paused after repeating itself.</span>
+      </span>
+      {% endif %}
+      {% if msg['role'] != 'user' and not msg_meta.get('error') %}
+      {{ render_meta_chips(msg['id'], msg.get('tags', [])) }}
       {% endif %}
     </div>
-    {% if repeat_guard %}
-    <span class="repeat-guard-indicator repeat-guard-indicator--visible repeat-guard-indicator--calm">
-      <span class="repeat-guard-indicator__label">response trimmed</span>
-      <span class="visually-hidden">Response paused after repeating itself.</span>
-    </span>
-    {% endif %}
-    {% if msg['role'] != 'user' and not msg_meta.get('error') %}
-    {{ render_meta_chips(msg['id'], msg.get('tags', [])) }}
-    {% endif %}
-  </div>
   {% endfor %}
   {% if opening_stream %}
   {{ assistant_stream('opening', day, sse_url=url_for('chat.sse_opening', date=day)) }}

--- a/src/llamora/app/templates/partials/message_divider.html
+++ b/src/llamora/app/templates/partials/message_divider.html
@@ -1,0 +1,13 @@
+{% set skip = divider.get('sr_skip') %}
+<div id="{{ divider.id }}"
+     class="message-divider no-anim"
+     data-phase="{{ divider.phase }}"
+     role="separator"
+     aria-label="{{ divider.accessible_label }}"
+     {% if skip %}aria-hidden="true"{% endif %}>
+  <span class="message-divider__content" aria-hidden="true">
+    <span class="message-divider__phase">{{ divider.phase_label }}</span>
+    <span class="message-divider__bullet" aria-hidden="true">•</span>
+    <time class="message-divider__time" datetime="{{ divider.datetime }}">{{ divider.time_label }}</time>
+  </span>
+</div>

--- a/tests/services/test_history_serializer.py
+++ b/tests/services/test_history_serializer.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from llamora.app.services.history_serializer import (
+    PHASE_LABELS,
+    serialize_history_for_view,
+)
+
+
+def _message(
+    msg_id: str,
+    created_at: str,
+    role: str = "user",
+    message: str = "",
+    meta: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": msg_id,
+        "created_at": created_at,
+        "role": role,
+        "message": message,
+        "meta": meta or {},
+        "prompt_tokens": 0,
+        "tags": [],
+    }
+
+
+def test_inserts_dividers_for_new_hour_blocks() -> None:
+    history = [
+        _message("a", "2025-01-02T04:15:00+00:00", "user"),
+        _message("b", "2025-01-02T04:45:00+00:00", "assistant"),
+        _message("c", "2025-01-02T08:05:00+00:00", "user"),
+        _message("d", "2025-01-02T17:35:00+00:00", "assistant"),
+    ]
+
+    items = serialize_history_for_view(history, "UTC")
+    kinds = [item["item_type"] for item in items]
+
+    assert kinds == [
+        "divider",
+        "message",
+        "message",
+        "divider",
+        "message",
+        "divider",
+        "message",
+    ]
+
+    first_divider = items[0]
+    assert first_divider["label"] == "Night • 04:00"
+    assert first_divider["phase"] == "night"
+
+    morning_divider = items[3]
+    assert morning_divider["label"] == "Morning • 08:00"
+    assert morning_divider["phase"] == "morning"
+
+    evening_divider = items[5]
+    assert evening_divider["label"] == "Evening • 17:00"
+    assert evening_divider["phase"] == "evening"
+
+
+@pytest.mark.parametrize(
+    "timezone_name, expected_times",
+    [
+        ("America/New_York", ["01:00", "02:00"]),
+        ("Asia/Tokyo", ["14:00", "15:00"]),
+    ],
+)
+def test_respects_timezone_when_bucketing(timezone_name: str, expected_times: list[str]) -> None:
+    history = [
+        _message("a", "2025-03-15T05:15:00+00:00"),
+        _message("b", "2025-03-15T06:05:00+00:00"),
+    ]
+
+    items = serialize_history_for_view(history, timezone_name)
+    dividers = [item for item in items if item["item_type"] == "divider"]
+
+    assert [divider["time_label"] for divider in dividers] == expected_times
+    assert {divider["phase"] for divider in dividers} <= set(PHASE_LABELS)


### PR DESCRIPTION
## Summary
- add a history serializer that inserts part-of-day dividers when the hour changes and expose it via the chat context
- render and style a reusable message divider partial with time-of-day gradients and scroll-safe behavior
- cover the divider logic with serializer unit tests across hour and timezone boundaries

## Testing
- PYTHONPATH=src uv run pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691084588e94832eb08e02929a29b76e)